### PR TITLE
Fixes #57

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ package-lock.json
 # misc
 .coverage
 .vscode
+*.code-workspace
 coverage.xml
 .ruff_cache
 *.zip

--- a/custom_components/home_maintenance/__init__.py
+++ b/custom_components/home_maintenance/__init__.py
@@ -38,10 +38,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     @callback
     def handle_tag_scanned_event(event: Event) -> None:
         """Handle when a tag is scanned."""
-        tag_id = event.data.get("tag_id")
+        tag_id = event.data.get("tag_id")  # Actually tag UUID
 
         store = hass.data[const.DOMAIN].get("store")
-        tasks = store.get_by_tag_id(tag_id)
+        tasks = store.get_by_tag_uuid(tag_id)
         if not tasks:
             return
 


### PR DESCRIPTION
Fixes a regression after [PR34](https://github.com/TJPoorman/home_maintenance/pull/34). Using ha-form to pull tags causes the tag_id for new/edited tasks to be the slugified name while tag scanned events use the tag's UUID. This change maps tag_ids to UUIDs before matching tasks against the event.